### PR TITLE
Increase eval_steps to 100

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -189,7 +189,7 @@ def train(
         logging_strategy="steps",
         logging_steps=10,
         evaluation_strategy="steps",
-        eval_steps=10,
+        eval_steps=200,
         save_strategy="steps",
         save_steps=200,
         save_total_limit=1,

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -189,7 +189,7 @@ def train(
         logging_strategy="steps",
         logging_steps=10,
         evaluation_strategy="steps",
-        eval_steps=200,
+        eval_steps=100,
         save_strategy="steps",
         save_steps=200,
         save_total_limit=1,


### PR DESCRIPTION
I think eval_steps=10 is too low. With a batch size of 8*8 = 64, 10 steps is 640 inputs. The eval set is 1000 inputs. This means running eval (which is, albeit, faster) on more data than was processed since the last eval. I arbitrarily increased this to 100. This means less time spent on eval, which seemed to be taking quite non-trivial time (maybe 15-30% of training time? highly depends on the setup), but also means less frequent eval. With only about 800 total steps you get 8 evals.

Interested in thoughts on this.