### PR TITLE
Improve tokenization to work with other tokenizers

### DIFF
--- a/training/consts.py
+++ b/training/consts.py
@@ -1,9 +1,8 @@
 DEFAULT_TRAINING_DATASET = "tatsu-lab/alpaca"
 DEFAULT_INPUT_MODEL = "EleutherAI/gpt-j-6B"
-RESPONSE_KEY = "### Response:"
 END_KEY = "### End"
 INSTRUCTION_KEY = "### Instruction:"
-RESPONSE_KEY_NL = f"{RESPONSE_KEY}\n"
+RESPONSE_KEY_NL = f"### Response:\n"
 DEFAULT_SEED = 42
 
 # The format of the instruction the model has been trained on.

--- a/training/generate.py
+++ b/training/generate.py
@@ -9,7 +9,7 @@ from transformers import (
     PreTrainedTokenizer,
 )
 
-from .consts import END_KEY, PROMPT_FORMAT, RESPONSE_KEY
+from .consts import END_KEY, PROMPT_FORMAT, RESPONSE_KEY_NL
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ def generate_response(
     """
     input_ids = tokenizer(PROMPT_FORMAT.format(instruction=instruction), return_tensors="pt").input_ids.to("cuda")
 
-    response_key_token_id = get_special_token_id(tokenizer, RESPONSE_KEY)
+    response_key_token_id = get_special_token_id(tokenizer, RESPONSE_KEY_NL)
     end_key_token_id = get_special_token_id(tokenizer, END_KEY)
 
     gen_tokens = model.generate(


### PR DESCRIPTION
This addresses #4.  The tokenizer used by bloom appears to combine the newline after `## Response:` with the following character, which does not happen with GPT-J 6b.  This results in the tokens for `### Response:\n` being different when appearing in the text compared to when it is tokenized in isolation.  My solution here is to change the key to `### Response:\n" so that this becomes a single token.  

The other fix is to try getting a different config setting for the max length, or fallback to 1024 if none can be found.

I've tested this on [bloomz-7b1-mt](https://huggingface.co/bigscience/bloomz-7b1-mt) and it produces similar generation quality.  It also still trains successfully using GPT-J 6B as the base model.