### PR TITLE
Suggest loading model in bfloat16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .dbx/
 venv/
 .venv/
+.idea/
 .python-version
 __pycache__/
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ First, load the model and tokenizer:
 
 ```
 import numpy as np
+import torch
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -39,7 +40,7 @@ from transformers import (
 )
 
 tokenizer = AutoTokenizer.from_pretrained("databricks/dolly-v1-6b", padding_side="left")
-model = AutoModelForCausalLM.from_pretrained("databricks/dolly-v1-6b", device_map="auto", trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained("databricks/dolly-v1-6b", device_map="auto", torch_dtype=torch.bfloat16, trust_remote_code=True)
 ```
 
 Next, try generating a response:

--- a/training/generate.py
+++ b/training/generate.py
@@ -2,6 +2,7 @@ import logging
 from typing import Tuple
 
 import numpy as np
+import torch
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -27,7 +28,7 @@ def load_model_tokenizer_for_generate(
     """
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path, padding_side="left")
     model = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path, device_map="auto", trust_remote_code=True
+        pretrained_model_name_or_path, device_map="auto", torch_dtype=torch.bfloat16, trust_remote_code=True
     )
     return model, tokenizer
 

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import click
 import numpy as np
+import torch
 from datasets import Dataset, load_dataset
 from transformers import (
     AutoModelForCausalLM,
@@ -112,7 +113,8 @@ def load_model(
 ) -> AutoModelForCausalLM:
     logger.info(f"Loading model for {pretrained_model_name_or_path}")
     model = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path, trust_remote_code=True, use_cache=False if gradient_checkpointing else True
+        pretrained_model_name_or_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
+        use_cache=False if gradient_checkpointing else True
     )
     return model
 


### PR DESCRIPTION
I'd suggest we show loading the model in bfloat16, as it seems like it will otherwise default to float32. I could be wrong about that, but it came to mind from https://github.com/databrickslabs/dolly/issues/52 and another customer conversation.

Any concerns? One issue is that you'd have to change to float16 on pre-Ampere GPUs, but, probably more changes and know-how are needed anyway, and you get a pretty clear error if you try bfloat16 on these.

(Also, because of `import torch`, or generally, should we include a fixed torch version in requirements.txt?)