### PR TITLE
Dolly V2 Updates

### DIFF
--- a/examples/generation.py
+++ b/examples/generation.py
@@ -1,0 +1,52 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ## Generation Example
+# MAGIC
+# MAGIC This takes a pretrained Dolly model, either from Hugging face or from a local path, and runs generation with it
+# MAGIC using the code from this repo.
+# MAGIC
+# MAGIC The model to load for generation is controlled by `input_model`.  The default options are the pretrained
+# MAGIC Dolly models shared on Hugging Face.  Alternatively, the path to a local model that has been trained using the
+# MAGIC `train_dolly` notebook can also be used.
+
+# COMMAND ----------
+
+# MAGIC %pip install -r ../requirements.txt
+
+# COMMAND ----------
+
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+default_model = "databricks/dolly-v2-3b"
+
+suggested_models = [
+    "databricks/dolly-v1-6b",
+    "databricks/dolly-v2-3b",
+    "databricks/dolly-v2-7b",
+    "databricks/dolly-v2-12b",
+]
+
+dbutils.widgets.combobox("input_model", default_model, suggested_models, "input_model")
+
+# COMMAND ----------
+
+from training.generate import generate_response, load_model_tokenizer_for_generate
+
+input_model = dbutils.widgets.get("input_model")
+
+model, tokenizer = load_model_tokenizer_for_generate(input_model)
+
+# COMMAND ----------
+
+# Examples from https://www.databricks.com/blog/2023/03/24/hello-dolly-democratizing-magic-chatgpt-open-models.html
+instructions = [
+    "Explain to me the difference between nuclear fission and fusion.",
+    "Give me a list of 5 science fiction books I should read next.",
+]
+
+# Use the model to generate responses for each of the instructions above.
+for instruction in instructions:
+    response = generate_response(instruction, model=model, tokenizer=tokenizer)
+    if response:
+        print(f"Instruction: {instruction}\n\n{response}\n\n-----------\n")

--- a/examples/langchain.py
+++ b/examples/langchain.py
@@ -1,0 +1,92 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ## Langchain Example
+# MAGIC
+# MAGIC This takes a pretrained Dolly model, either from Hugging face or from a local path, and uses langchain
+# MAGIC to run generation.
+# MAGIC
+# MAGIC The model to load for generation is controlled by `input_model`.  The default options are the pretrained
+# MAGIC Dolly models shared on Hugging Face.  Alternatively, the path to a local model that has been trained using the
+# MAGIC `train_dolly` notebook can also be used.
+
+# COMMAND ----------
+
+# MAGIC %pip install -r ../requirements.txt
+
+# COMMAND ----------
+
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+# COMMAND ----------
+
+default_model = "databricks/dolly-v2-3b"
+
+suggested_models = [
+    "databricks/dolly-v1-6b",
+    "databricks/dolly-v2-3b",
+    "databricks/dolly-v2-7b",
+    "databricks/dolly-v2-12b",
+]
+
+dbutils.widgets.combobox("input_model", default_model, suggested_models, "input_model")
+
+# COMMAND ----------
+
+from training.generate import InstructionTextGenerationPipeline, load_model_tokenizer_for_generate
+
+input_model = dbutils.widgets.get("input_model")
+
+model, tokenizer = load_model_tokenizer_for_generate(input_model)
+
+# COMMAND ----------
+
+from langchain import PromptTemplate, LLMChain
+from langchain.llms import HuggingFacePipeline
+
+# template for an instrution with no input
+prompt = PromptTemplate(
+    input_variables=["instruction"],
+    template="{instruction}")
+
+# template for an instruction with input
+prompt_with_context = PromptTemplate(
+    input_variables=["instruction", "context"],
+    template="{instruction}\n\nInput:\n{context}")
+
+hf_pipeline = HuggingFacePipeline(
+    pipeline=InstructionTextGenerationPipeline(
+        # Return the full text, because this is what the HuggingFacePipeline expects.
+        model=model, tokenizer=tokenizer, return_full_text=True, task="text-generation"))
+
+llm_chain = LLMChain(llm=hf_pipeline, prompt=prompt)
+llm_context_chain = LLMChain(llm=hf_pipeline, prompt=prompt_with_context)
+
+# COMMAND ----------
+
+# Examples from https://www.databricks.com/blog/2023/03/24/hello-dolly-democratizing-magic-chatgpt-open-models.html
+instructions = [
+    "Explain to me the difference between nuclear fission and fusion.",
+    "Give me a list of 5 science fiction books I should read next.",
+]
+
+# Use the model to generate responses for each of the instructions above.
+for instruction in instructions:
+    response = llm_chain.predict(instruction=instruction)
+    print(f"Instruction: {instruction}\n\n{response}\n\n-----------\n")
+
+# COMMAND ----------
+
+context = (
+    """George Washington (February 22, 1732[b] – December 14, 1799) was an American military officer, statesman, """
+    """and Founding Father who served as the first president of the United States from 1789 to 1797. Appointed by """
+    """the Continental Congress as commander of the Continental Army, Washington led Patriot forces to victory in """
+    """the American Revolutionary War and served as president of the Constitutional Convention of 1787, which """
+    """created and ratified the Constitution of the United States and the American federal government. Washington """
+    """has been called the "Father of his Country" for his manifold leadership in the nation's founding."""
+)
+
+instruction = "When did George Washinton serve as president of the Constitutional Convention?"
+
+response = llm_context_chain.predict(instruction=instruction, context=context)
+print(f"Instruction: {instruction}\n\nContext:\n{context}\n\nResponse:\n{response}\n\n-----------\n")

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -1,0 +1,58 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ## Pipeline Example
+# MAGIC
+# MAGIC This takes a pretrained Dolly model, either from Hugging face or from a local path, and uses the pipeline from
+# MAGIC this repo to perform generation.
+# MAGIC
+# MAGIC The model to load for generation is controlled by `input_model`.  The default options are the pretrained
+# MAGIC Dolly models shared on Hugging Face.  Alternatively, the path to a local model that has been trained using the
+# MAGIC `train_dolly` notebook can also be used.
+
+# COMMAND ----------
+
+# MAGIC %pip install -r ../requirements.txt
+
+# COMMAND ----------
+
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+default_model = "databricks/dolly-v2-3b"
+
+suggested_models = [
+    "databricks/dolly-v1-6b",
+    "databricks/dolly-v2-3b",
+    "databricks/dolly-v2-7b",
+    "databricks/dolly-v2-12b",
+]
+
+dbutils.widgets.combobox("input_model", default_model, suggested_models, "input_model")
+
+# COMMAND ----------
+
+from training.generate import InstructionTextGenerationPipeline, load_model_tokenizer_for_generate
+
+input_model = dbutils.widgets.get("input_model")
+
+model, tokenizer = load_model_tokenizer_for_generate(input_model)
+
+# COMMAND ----------
+
+generation_pipeline = InstructionTextGenerationPipeline(model=model, tokenizer=tokenizer)
+
+# Examples from https://www.databricks.com/blog/2023/03/24/hello-dolly-democratizing-magic-chatgpt-open-models.html
+instructions = [
+    "Explain to me the difference between nuclear fission and fusion.",
+    "Give me a list of 5 science fiction books I should read next.",
+]
+
+# Use the model to generate responses for each of the instructions above.
+for instruction in instructions:
+    results = generation_pipeline(instruction, num_return_sequences=2)
+
+    print(f"Instruction: {instruction}\n")
+    for i, res in enumerate(results, 1):
+        text = res["generated_text"]
+        print(f"Sample #{i}:\n{text}\n")
+    print("-----------\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ click==8.0.3
 datasets==2.8.0
 deepspeed==0.8.0
 transformers[torch]==4.25.1
-watchdog==2.1.9
+langchain>=0.0.139

--- a/training/consts.py
+++ b/training/consts.py
@@ -1,18 +1,74 @@
-DEFAULT_TRAINING_DATASET = "tatsu-lab/alpaca"
-DEFAULT_INPUT_MODEL = "EleutherAI/gpt-j-6B"
-END_KEY = "### End"
+DEFAULT_INPUT_MODEL = "EleutherAI/pythia-6.9b"
+SUGGESTED_INPUT_MODELS = [
+    "EleutherAI/pythia-2.8b",
+    "EleutherAI/pythia-6.9b",
+    "EleutherAI/pythia-12b",
+    "EleutherAI/gpt-j-6B",
+]
+INTRO_BLURB = (
+    "Below is an instruction that describes a task. Write a response that appropriately completes the request."
+)
 INSTRUCTION_KEY = "### Instruction:"
-RESPONSE_KEY_NL = f"### Response:\n"
+INPUT_KEY = "Input:"
+RESPONSE_KEY = "### Response:"
+END_KEY = "### End"
+RESPONSE_KEY_NL = f"{RESPONSE_KEY}\n"
 DEFAULT_SEED = 42
 
-# The format of the instruction the model has been trained on.
-PROMPT_FORMAT = """%s
+# This is a training prompt that does not contain an input string.  The instruction by itself has enough information
+# to respond.  For example, the instruction might ask for the year a historic figure was born.
+PROMPT_NO_INPUT_FORMAT = """{intro}
 
-%s
+{instruction_key}
 {instruction}
 
-%s""" % (
-    "Below is an instruction that describes a task. Write a response that appropriately completes the request.",
-    INSTRUCTION_KEY,
-    RESPONSE_KEY_NL,
+{response_key}
+{response}
+
+{end_key}""".format(
+    intro=INTRO_BLURB,
+    instruction_key=INSTRUCTION_KEY,
+    instruction="{instruction}",
+    response_key=RESPONSE_KEY,
+    response="{response}",
+    end_key=END_KEY,
+)
+
+# This is a training prompt that contains an input string that serves as context for the instruction.  For example,
+# the input might be a passage from Wikipedia and the intruction is to extract some information from it.
+PROMPT_WITH_INPUT_FORMAT = """{intro}
+
+{instruction_key}
+{instruction}
+
+{input_key}
+{input}
+
+{response_key}
+{response}
+
+{end_key}""".format(
+    intro=INTRO_BLURB,
+    instruction_key=INSTRUCTION_KEY,
+    instruction="{instruction}",
+    input_key=INPUT_KEY,
+    input="{input}",
+    response_key=RESPONSE_KEY,
+    response="{response}",
+    end_key=END_KEY,
+)
+
+# This is the prompt that is used for generating responses using an already trained model.  It ends with the response
+# key, where the job of the model is to provide the completion that follows it (i.e. the response itself).
+PROMPT_FOR_GENERATION_FORMAT = """{intro}
+
+{instruction_key}
+{instruction}
+
+{response_key}
+""".format(
+    intro=INTRO_BLURB,
+    instruction_key=INSTRUCTION_KEY,
+    instruction="{instruction}",
+    response_key=RESPONSE_KEY,
 )

--- a/training/generate.py
+++ b/training/generate.py
@@ -107,7 +107,8 @@ class InstructionTextGenerationPipeline(Pipeline):
             "end_key_token_id": end_key_token_id
         }
 
-        postprocess_params["return_full_text"] = return_full_text if return_full_text is not None else False
+        if return_full_text is not None:
+            postprocess_params["return_full_text"] = return_full_text
 
         return preprocess_params, forward_params, postprocess_params
 
@@ -148,7 +149,7 @@ class InstructionTextGenerationPipeline(Pipeline):
         instruction_text = model_inputs.pop("instruction_text")
         return {"generated_sequence": generated_sequence, "input_ids": input_ids, "instruction_text": instruction_text}
 
-    def postprocess(self, model_outputs, response_key_token_id, end_key_token_id, return_full_text):
+    def postprocess(self, model_outputs, response_key_token_id, end_key_token_id, return_full_text: bool = False):
 
         generated_sequence = model_outputs["generated_sequence"][0]
         instruction_text = model_outputs["instruction_text"]

--- a/training/generate.py
+++ b/training/generate.py
@@ -1,15 +1,22 @@
 import logging
-from typing import Tuple
+import re
+from typing import List, Tuple
 
 import numpy as np
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
+    Pipeline,
     PreTrainedModel,
     PreTrainedTokenizer,
 )
 
-from .consts import END_KEY, PROMPT_FORMAT, RESPONSE_KEY_NL
+from transformers.utils import is_tf_available
+
+if is_tf_available():
+    import tensorflow as tf
+
+from .consts import END_KEY, PROMPT_FOR_GENERATION_FORMAT, RESPONSE_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -54,73 +61,178 @@ def get_special_token_id(tokenizer: PreTrainedTokenizer, key: str) -> int:
     return token_ids[0]
 
 
+class InstructionTextGenerationPipeline(Pipeline):
+    def __init__(
+        self, *args, do_sample: bool = True, max_new_tokens: int = 256, top_p: float = 0.92, top_k: int = 0, **kwargs
+    ):
+        """Initialize the pipeline
+
+        Args:
+            do_sample (bool, optional): Whether or not to use sampling. Defaults to True.
+            max_new_tokens (int, optional): Max new tokens after the prompt to generate. Defaults to 128.
+            top_p (float, optional): If set to float < 1, only the smallest set of most probable tokens with
+                probabilities that add up to top_p or higher are kept for generation. Defaults to 0.92.
+            top_k (int, optional): The number of highest probability vocabulary tokens to keep for top-k-filtering.
+                Defaults to 0.
+        """
+        super().__init__(*args, do_sample=do_sample, max_new_tokens=max_new_tokens, top_p=top_p, top_k=top_k,
+                         **kwargs)
+
+    def _sanitize_parameters(self,
+                             return_full_text: bool = None,
+                             **generate_kwargs):
+        preprocess_params = {}
+
+        # newer versions of the tokenizer configure the response key as a special token.  newer versions still may
+        # append a newline to yield a single token.  find whatever token is configured for the response key.
+        tokenizer_response_key = next(
+            (token for token in self.tokenizer.additional_special_tokens if token.startswith(RESPONSE_KEY)), None
+        )
+
+        response_key_token_id = None
+        end_key_token_id = None
+        if tokenizer_response_key:
+            try:
+                response_key_token_id = get_special_token_id(self.tokenizer, tokenizer_response_key)
+                end_key_token_id = get_special_token_id(self.tokenizer, END_KEY)
+
+                # Ensure generation stops once it generates "### End"
+                generate_kwargs["eos_token_id"] = end_key_token_id
+            except ValueError:
+                pass
+
+        forward_params = generate_kwargs
+        postprocess_params = {
+            "response_key_token_id": response_key_token_id,
+            "end_key_token_id": end_key_token_id
+        }
+
+        postprocess_params["return_full_text"] = return_full_text if return_full_text is not None else False
+
+        return preprocess_params, forward_params, postprocess_params
+
+    def preprocess(self, instruction_text, **generate_kwargs):
+        prompt_text = PROMPT_FOR_GENERATION_FORMAT.format(instruction=instruction_text)
+        inputs = self.tokenizer(
+            prompt_text,
+            return_tensors="pt",
+        )
+        inputs["prompt_text"] = prompt_text
+        inputs["instruction_text"] = instruction_text
+        return inputs
+
+    def _forward(self, model_inputs, **generate_kwargs):
+        input_ids = model_inputs["input_ids"]
+        attention_mask = model_inputs.get("attention_mask", None)
+
+        if input_ids.shape[1] == 0:
+            input_ids = None
+            attention_mask = None
+            in_b = 1
+        else:
+            in_b = input_ids.shape[0]
+
+        generated_sequence = self.model.generate(
+            input_ids=input_ids.to(self.model.device),
+            attention_mask=attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            **generate_kwargs,
+        )
+
+        out_b = generated_sequence.shape[0]
+        if self.framework == "pt":
+            generated_sequence = generated_sequence.reshape(in_b, out_b // in_b, *generated_sequence.shape[1:])
+        elif self.framework == "tf":
+            generated_sequence = tf.reshape(generated_sequence, (in_b, out_b // in_b, *generated_sequence.shape[1:]))
+
+        instruction_text = model_inputs.pop("instruction_text")
+        return {"generated_sequence": generated_sequence, "input_ids": input_ids, "instruction_text": instruction_text}
+
+    def postprocess(self, model_outputs, response_key_token_id, end_key_token_id, return_full_text):
+
+        generated_sequence = model_outputs["generated_sequence"][0]
+        instruction_text = model_outputs["instruction_text"]
+
+        generated_sequence: List[List[int]] = generated_sequence.numpy().tolist()
+        records = []
+        for sequence in generated_sequence:
+
+            # The response will be set to this variable if we can identify it.
+            decoded = None
+
+            # If we have token IDs for the response and end, then we can find the tokens and only decode between them.
+            if response_key_token_id and end_key_token_id:
+                # Find where "### Response:" is first found in the generated tokens.  Considering this is part of the
+                # prompt, we should definitely find it.  We will return the tokens found after this token.
+                try:
+                    response_pos = sequence.index(response_key_token_id)
+                except ValueError:
+                    logger.warn(f"Could not find response key {response_key_token_id} in: {sequence}")
+                    response_pos = None
+
+                if response_pos:
+                    # Next find where "### End" is located.  The model has been trained to end its responses with this
+                    # sequence (or actually, the token ID it maps to, since it is a special token).  We may not find
+                    # this token, as the response could be truncated.  If we don't find it then just return everything
+                    # to the end.  Note that even though we set eos_token_id, we still see the this token at the end.
+                    try:
+                        end_pos = sequence.index(end_key_token_id)
+                    except ValueError:
+                        end_pos = None
+
+                    decoded = self.tokenizer.decode(sequence[response_pos + 1 : end_pos]).strip()
+
+            if not decoded:
+                # Otherwise we'll decode everything and use a regex to find the response and end.
+
+                fully_decoded = self.tokenizer.decode(sequence)
+
+                # The response appears after "### Response:".  The model has been trained to append "### End" at the
+                # end.
+                m = re.search(r"#+\s*Response:\s*(.+?)#+\s*End", fully_decoded, flags=re.DOTALL)
+
+                if m:
+                    decoded = m.group(1).strip()
+                else:
+                    # The model might not generate the "### End" sequence before reaching the max tokens.  In this case,
+                    # return everything after "### Response:".
+                    m = re.search(r"#+\s*Response:\s*(.+)", fully_decoded, flags=re.DOTALL)
+                    if m:
+                        decoded = m.group(1).strip()
+                    else:
+                        logger.warn(f"Failed to find response in:\n{fully_decoded}")
+
+            # If the full text is requested, then append the decoded text to the original instruction.
+            # This technically isn't the full text, as we format the instruction in the prompt the model has been
+            # trained on, but to the client it will appear to be the full text.
+            if return_full_text:
+                decoded = f"{instruction_text}\n{decoded}"
+
+            rec = {"generated_text": decoded}
+
+            records.append(rec)
+
+        return records
+
+
 def generate_response(
     instruction: str,
     *,
     model: PreTrainedModel,
     tokenizer: PreTrainedTokenizer,
-    do_sample: bool = True,
-    max_new_tokens: int = 256,
-    top_p: float = 0.92,
-    top_k: int = 0,
     **kwargs,
 ) -> str:
     """Given an instruction, uses the model and tokenizer to generate a response.  This formats the instruction in
     the instruction format that the model was fine-tuned on.
 
     Args:
-        instruction (str): instruction to generate response for
-        model (PreTrainedModel): model to use
-        tokenizer (PreTrainedTokenizer): tokenizer to use
-        do_sample (bool, optional): Whether or not to use sampling. Defaults to True.
-        max_new_tokens (int, optional): Max new tokens after the prompt to generate. Defaults to 128.
-        top_p (float, optional): If set to float < 1, only the smallest set of most probable tokens with probabilities
-            that add up to top_p or higher are kept for generation. Defaults to 0.92.
-        top_k (int, optional): The number of highest probability vocabulary tokens to keep for top-k-filtering.
-            Defaults to 0.
+        instruction (str): _description_
+        model (PreTrainedModel): the model to use
+        tokenizer (PreTrainedTokenizer): the tokenizer to use
 
     Returns:
-        str: the generated response
+        str: response
     """
-    input_ids = tokenizer(PROMPT_FORMAT.format(instruction=instruction), return_tensors="pt").input_ids.to("cuda")
 
-    response_key_token_id = get_special_token_id(tokenizer, RESPONSE_KEY_NL)
-    end_key_token_id = get_special_token_id(tokenizer, END_KEY)
-
-    gen_tokens = model.generate(
-        input_ids,
-        pad_token_id=tokenizer.pad_token_id,
-        # Ensure generation stops once it generates "### End"
-        eos_token_id=end_key_token_id,
-        do_sample=do_sample,
-        max_new_tokens=max_new_tokens,
-        top_p=top_p,
-        top_k=top_k,
-        **kwargs,
-    )[0].cpu()
-
-    # The response will be set to this variable if we can identify it.
-    decoded = None
-
-    # Find where "### Response:" is first found in the generated tokens.  Considering this is part of the prompt,
-    # we should definitely find it.  We will return the tokens found after this token.
-    response_pos = None
-    response_positions = np.where(gen_tokens == response_key_token_id)[0]
-    if len(response_positions) == 0:
-        logger.warn(f"Could not find response key {response_key_token_id} in: {gen_tokens}")
-    else:
-        response_pos = response_positions[0]
-
-    if response_pos:
-        # Next find where "### End" is located.  The model has been trained to end its responses with this sequence
-        # (or actually, the token ID it maps to, since it is a special token).  We may not find this token, as the
-        # response could be truncated.  If we don't find it then just return everything to the end.  Note that
-        # even though we set eos_token_id, we still see the this token at the end.
-        end_pos = None
-        end_positions = np.where(gen_tokens == end_key_token_id)[0]
-        if len(end_positions) > 0:
-            end_pos = end_positions[0]
-
-        decoded = tokenizer.decode(gen_tokens[response_pos + 1 : end_pos]).strip()
-
-    return decoded
+    generation_pipeline = InstructionTextGenerationPipeline(model=model, tokenizer=tokenizer, **kwargs)
+    return generation_pipeline(instruction)[0]["generated_text"]


### PR DESCRIPTION
This updates training to use the [`databricks-dolly-15k`](https://github.com/databrickslabs/dolly/tree/master/data) dataset.  It also includes improvements to text generation and example notebooks.

Key Changes:
* The `train_dolly.py` notebook now uses Pythia models as the input models and fine tunes using the [`databricks-dolly-15k`](https://github.com/databrickslabs/dolly/tree/master/data) dataset.
* Added `InstructionTextGenerationPipeline` for text generation.  This is derived from the code in the model repo, [instruct_pipeline.py](https://huggingface.co/databricks/dolly-v2-12b/blob/main/instruct_pipeline.py).  It has been improved so that it is compatible with the `TextGenerationPipeline` from the `transformers` library.  Some code, such as that in `_forward`, was copied from that pipeline to help with compatibility.  The biggest change relative to the current `instruct_pipeline.py` version is that it returns a list of dicts per instruction, rather than just a dict.  It also now has a `return_full_text` option.  Both of these contribute towards being usable with `langchain`.
* `generate_response` is now a wrapper around `InstructionTextGenerationPipeline`, as the code was all moved there.
* `trainer.py` now uses the local `databricks-dolly-15k.jsonl` dataset.  A `text` column has been constructed from the instruction, context, and response.

Minor Changes:
* Added an `experiment_id` widget to help keep track of different models that are fine tuned.
* Added more options to CLI for configuring training.

Additional Changes:
* Added a `generation.py` example notebook that uses `generate_response` on a couple instructions.
* Added a `langchain.py` example notebook that uses `HuggingFacePipeline ` from `langchain` and `InstructionTextGenerationPipeline ` to test instructions both with and without context.
* Added a `pipeline.py` example notebook that uses `InstructionTextGenerationPipeline` to generate multiple samples per instruction.