### PR TITLE
Suggest bfloat16 and add generation notes for A10, V100

### DIFF
--- a/training/generate.py
+++ b/training/generate.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from typing import List, Tuple
+import torch
 
 import numpy as np
 from transformers import (
@@ -34,7 +35,7 @@ def load_model_tokenizer_for_generate(
     """
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path, padding_side="left")
     model = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path, device_map="auto", trust_remote_code=True
+        pretrained_model_name_or_path, device_map="auto", torch_dtype=torch.bfloat16, trust_remote_code=True
     )
     return model, tokenizer
 


### PR DESCRIPTION
I propose we explicitly show loading in bf16 over fp32 in the generation example and in the generation code. This helps avoid OOM for sure in many usages.

I add additional notes on getting generation to work on A10, V100 GPUs with 8-bit.