### PR TITLE
Drop back to deepspeed 0.8.3 because of issues with 0.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 accelerate>=0.16.0,<1
 click>=8.0.4,<9
 datasets>=2.10.0,<3
-deepspeed>=0.9.0,<1
+deepspeed>=0.8.3,<0.9
 transformers[torch]>=4.28.1,<5
 langchain>=0.0.139
 torch>=1.13.1,<2


### PR DESCRIPTION
Seems like deepspeed 0.9.x is causing some issues in training. Let's drop back to 0.8.3.
See https://github.com/databrickslabs/dolly/issues/125#issuecomment-1521876041