### PR TITLE
Update to Trainer.train to Allow Override Dataset

### DIFF
--- a/training/consts.py
+++ b/training/consts.py
@@ -5,6 +5,7 @@ SUGGESTED_INPUT_MODELS = [
     "EleutherAI/pythia-12b",
     "EleutherAI/gpt-j-6B",
 ]
+DEFAULT_TRAINING_DATASET = "databricks/databricks-dolly-15k"
 INTRO_BLURB = (
     "Below is an instruction that describes a task. Write a response that appropriately completes the request."
 )


### PR DESCRIPTION
This update adds a new parameter '--training-dataset' that can be optionally set at the deepspeed call to pass in an alternate dataset for training.

Adds a new constant for the databricks 15k dataset. 

Updates various Trainer functions to allow for a path override for the dataset.