### PR TITLE
Support for Training the Model Using Local Files

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -7,3 +7,10 @@ Please simply use `datasets` to load `databricks/databricks-dolly-15k`.
 
 The data file is directly accessible at 
 https://huggingface.co/datasets/databricks/databricks-dolly-15k/blob/main/databricks-dolly-15k.jsonl
+
+
+# Train the model using local files?
+
+Upload your training data to this folder and select "local_files" as the training_dataset in the "train_dolly" notebook.
+
+Currently, we support JSON, CSV, and Parquet file formats. See more details in https://huggingface.co/docs/datasets/loading#local-and-remote-files

--- a/train_dolly.py
+++ b/train_dolly.py
@@ -95,7 +95,7 @@ dbutils.widgets.text("experiment_id", "", "experiment_id")
 dbutils.widgets.dropdown("training_dataset", DEFAULT_TRAINING_DATASET, [DEFAULT_TRAINING_DATASET, "local_file"])
 if dbutils.widgets.get("training_dataset") == "local_file":
   # Train with the local file. 
-  dbutils.widgets.text("local_file_name", "", "local_file_name")
+  dbutils.widgets.text("local_file_name", "[file name in data dir]", "local_file_name")
   dbutils.widgets.dropdown("local_file_type", "JSON", ["JSON", "CSV", "Parquet"])
 else:
   try:
@@ -108,7 +108,9 @@ else:
 
 # Cache data and tokenizer locally before creating a bunch of deepspeed processes and make sure they succeeds.
 training_dataset = dbutils.widgets.get("training_dataset")
-load_training_dataset(training_dataset, dbutils.widgets.get("local_file_name") if training_dataset != DEFAULT_TRAINING_DATASET else None)
+load_training_dataset(
+  dbutils.widgets.get("local_file_name") if training_dataset != DEFAULT_TRAINING_DATASET else DEFAULT_TRAINING_DATASET,
+  dbutils.widgets.get("local_file_type") if training_dataset != DEFAULT_TRAINING_DATASET else None)
 load_tokenizer()
 
 # COMMAND ----------

--- a/train_dolly.py
+++ b/train_dolly.py
@@ -108,7 +108,7 @@ else:
 
 # Cache data and tokenizer locally before creating a bunch of deepspeed processes and make sure they succeeds.
 training_dataset = dbutils.widgets.get("training_dataset")
-load_training_dataset(training_dataset, dbutils.widgets.get("local_file_type") if training_dataset != DEFAULT_TRAINING_DATASET else None)
+load_training_dataset(training_dataset, dbutils.widgets.get("local_file_name") if training_dataset != DEFAULT_TRAINING_DATASET else None)
 load_tokenizer()
 
 # COMMAND ----------

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -85,9 +85,18 @@ def preprocess_batch(batch: Dict[str, List], tokenizer: AutoTokenizer, max_lengt
     )
 
 
-def load_training_dataset(path_or_dataset: str = DEFAULT_TRAINING_DATASET) -> Dataset:
-    logger.info(f"Loading dataset from {path_or_dataset}")
-    dataset = load_dataset(path_or_dataset)["train"]
+def load_training_dataset(path_or_dataset: str = DEFAULT_TRAINING_DATASET, file_type: str = None) -> Dataset:
+    dataset = None
+    if file_type:
+      # read local file from the data dir
+      file_path = ROOT_PATH / "data" / path_or_dataset
+      if not Path(file_path).exists():
+        raise RuntimeError(f"Could not find data file {path_or_dataset} in data dir.")
+      logger.info(f"Loading dataset from {file_path}")
+      dataset = load_dataset(file_type, data_files=str(file_path))["train"]
+    else:
+      logger.info(f"Loading dataset from {path_or_dataset}")
+      dataset = load_dataset(path_or_dataset)["train"]
     logger.info("Found %d rows", dataset.num_rows)
 
     def _add_text(rec):


### PR DESCRIPTION
Add the support for training the model using local files.

- Modified the train_dolly notebook with new widgets for setting file name, file type
- Only support the local file uploaded in `data` directory.
- Added doc in data readme.

<img width="1222" alt="image" src="https://github.com/databrickslabs/dolly/assets/4833765/28f4ece0-5950-43d0-856a-61fc7ef3b2c7">
