### PR TITLE
Add Dolly as the Input Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Otherwise, follow the steps above. The 12B param model may not function well in 
 - Add the `dolly` repo to Databricks (under Repos click Add Repo, enter `https://github.com/databrickslabs/dolly.git`, then click Create Repo).
 - Start a `12.2 LTS ML (includes Apache Spark 3.3.2, GPU, Scala 2.12)` single-node cluster with node type having 8 A100 GPUs (e.g. `Standard_ND96asr_v4` or `p4d.24xlarge`). Note that these instance types may not be available in all regions, or may be difficult to provision. In Databricks, note that you must select the GPU runtime first, and unselect "Use Photon", for these instance types to appear (where supported).
 - Open the `train_dolly` notebook in the Repo (which is the `train_dolly.py` file in the Github `dolly` repo), attach to your GPU cluster, and run all cells.  When training finishes, the notebook will save the model under `/dbfs/dolly_training`.
-- You can also directly use Dolly as the input model and further train your own model using your file tuning records uploaded to the data directory. Simply upload the files and set `local_files` as the training_dataset in the `train_dolly` notebook.
 
 ### Training on Other Instances
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Otherwise, follow the steps above. The 12B param model may not function well in 
 - Add the `dolly` repo to Databricks (under Repos click Add Repo, enter `https://github.com/databrickslabs/dolly.git`, then click Create Repo).
 - Start a `12.2 LTS ML (includes Apache Spark 3.3.2, GPU, Scala 2.12)` single-node cluster with node type having 8 A100 GPUs (e.g. `Standard_ND96asr_v4` or `p4d.24xlarge`). Note that these instance types may not be available in all regions, or may be difficult to provision. In Databricks, note that you must select the GPU runtime first, and unselect "Use Photon", for these instance types to appear (where supported).
 - Open the `train_dolly` notebook in the Repo (which is the `train_dolly.py` file in the Github `dolly` repo), attach to your GPU cluster, and run all cells.  When training finishes, the notebook will save the model under `/dbfs/dolly_training`.
+- You can also directly use Dolly as the input model and further train your own model using your file tuning records uploaded to the data directory. Simply upload the files and set `local_files` as the training_dataset in the `train_dolly` notebook.
 
 ### Training on Other Instances
 

--- a/training/consts.py
+++ b/training/consts.py
@@ -4,9 +4,9 @@ SUGGESTED_INPUT_MODELS = [
     "EleutherAI/pythia-6.9b",
     "EleutherAI/pythia-12b",
     "EleutherAI/gpt-j-6B",
-    "databricks/dolly-v2-3b"
+    "databricks/dolly-v2-3b",
     "databricks/dolly-v2-7b",
-    "databricks/dolly-v2-12b",
+    "databricks/dolly-v2-12b"
 ]
 DEFAULT_TRAINING_DATASET = "databricks/databricks-dolly-15k"
 INTRO_BLURB = (

--- a/training/consts.py
+++ b/training/consts.py
@@ -4,6 +4,9 @@ SUGGESTED_INPUT_MODELS = [
     "EleutherAI/pythia-6.9b",
     "EleutherAI/pythia-12b",
     "EleutherAI/gpt-j-6B",
+    "databricks/dolly-v2-3b"
+    "databricks/dolly-v2-7b",
+    "databricks/dolly-v2-12b",
 ]
 DEFAULT_TRAINING_DATASET = "databricks/databricks-dolly-15k"
 INTRO_BLURB = (


### PR DESCRIPTION
Combine it with https://github.com/databrickslabs/dolly/pull/163. With the ability to train the model using local files, we can now include Dolly v2 models as an option in the suggested input models.

In our test scenario, we observed that fine-tuning based on Dolly yielded better performance compared to fine-tuning based on the base models directly.