### PR TITLE
Drop duplicate torch from requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
 pytest-cov==3.0.0
 pytest==7.1.2
-torch==1.13.1
 torchvision==0.14.1


### PR DESCRIPTION
installing with "pip install -r dolly/requirements_dev.txt" results in ERROR: Double requirement given: torch==1.13.1 (from -r dolly/requirements_dev.txt (line 4)) (already in torch<2,>=1.13.1 (from -r dolly/requirements.txt (line 7)), name='torch') with pip version pip 20.0.2