### PR TITLE
Set bf16 flags correctly for a10/a100

### DIFF
--- a/config/a100_config.json
+++ b/config/a100_config.json
@@ -1,6 +1,9 @@
 {
+    "fp16": {
+      "enabled": false
+    },
     "bf16": {
-      "enabled": "auto"
+      "enabled": true
     },
     "optimizer": {
       "type": "AdamW",

--- a/config/a10_config.json
+++ b/config/a10_config.json
@@ -1,6 +1,9 @@
 {
+    "fp16": {
+      "enabled": false
+    },
     "bf16": {
-      "enabled": "auto"
+      "enabled": true
     },
     "optimizer": {
       "type": "AdamW",

--- a/config/v100_config.json
+++ b/config/v100_config.json
@@ -2,6 +2,9 @@
     "fp16": {
       "enabled": true
     },
+    "bf16": {
+      "enabled": false
+    },
     "optimizer": {
       "type": "AdamW",
       "params": {

--- a/train_dolly.py
+++ b/train_dolly.py
@@ -160,6 +160,11 @@ if num_gpus:
     num_gpus = int(num_gpus)
     num_gpus_flag = f"--num_gpus={num_gpus}"
 
+if gpu_family == "v100":
+    bf16_flag = "--bf16 false"
+else:
+    bf16_flag = "--bf16 true"
+
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # COMMAND ----------
@@ -184,7 +189,8 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
     --eval-steps 50 \
     --warmup-steps 50 \
     --test-size 200 \
-    --lr 5e-6
+    --lr 5e-6 \
+    {bf16_flag}
 
 # COMMAND ----------
 


### PR DESCRIPTION
Follow-up to https://github.com/databrickslabs/dolly/commit/a33d774e857e1e19fcf74cf0357dc27c78a4cd06
We need to make sure `--bf16` is set according to the GPU type, as leaving it out will now otherwise default to fp32.
(I added corresponding deepspeed config, though arguably redundant, as a double-check)

CC @tnixon 